### PR TITLE
Get gdbstub crates from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,8 +55,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.6.0"
-source = "git+https://github.com/daniel5151/gdbstub.git?branch=dev/0.6#a7d4ff395ce37637fc330b72b3ee029f257593a7"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1f9371c87c11642ee94dcf92cb48b1484ba250b8e8bff3df71c28651f3f4e7"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -78,8 +79,9 @@ dependencies = [
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.2.0"
-source = "git+https://github.com/daniel5151/gdbstub.git?branch=dev/0.6#a7d4ff395ce37637fc330b72b3ee029f257593a7"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f469ba9556c5a063d6df35a8a338025fccf96ecae44f330a156b686f7a268"
 dependencies = [
  "gdbstub",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ stub_x86 = []
 stub_mips = []
 
 [dependencies]
-gdbstub_arch = { git = "https://github.com/daniel5151/gdbstub.git", branch = "dev/0.6" }
-gdbstub = { git = "https://github.com/daniel5151/gdbstub.git", branch = "dev/0.6" }
-# gdbstub_arch = { path = "../gdbstub/gdbstub_arch" }
-# gdbstub = { path = "../gdbstub/" }
-
+gdbstub = "0.6"
+gdbstub_arch = "0.2"
 log = "0.4"
 pretty_env_logger = "0.4"
+
+[patch.crates-io]
+# gdbstub = { path = "../gdbstub/" }
+# gdbstub_arch = { path = "../gdbstub/gdbstub_arch" }


### PR DESCRIPTION
This repo seems to now work with the released crates and shouldn't need to use a particular branch so get them from crates.io, instead.

To allow easy local testing, instead of having to replace the `[dependencies]` entries, add a `[patch]` section that can overshadow the crates.io crates by simply uncommenting one line per crate (no need to comment the `[dependencies]` lines).